### PR TITLE
Fix length assertion in `Tensor::slice`

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -144,7 +144,7 @@ impl Llama<f32> {
 fn self_attention(
     hidden_states: &mut Tensor<f32>, // (seq, n_kv_h * n_groups * dqkv)
     att_scores: &mut Tensor<f32>,    // (n_kv_h, n_groups, seq, total_seq)
-    q: &Tensor<f32>,                 // (seq, n_kv_h * n_groups * dqkv)
+    q: &Tensor<f32>,                 // (seq, n_kv_h * n_groups, dqkv)
     k: &Tensor<f32>,                 // (total_seq, n_kv_h * dqkv)
     v: &Tensor<f32>,                 // (total_seq, n_kv_h * dqkv)
     n_kv_h: usize,

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -53,7 +53,7 @@ impl<T: Copy + Clone + Default> Tensor<T> {
 
     pub fn slice(&self, start: usize, shape: &Vec<usize>) -> Self {
         let new_length: usize = shape.iter().product();
-        assert!(self.offset + start + new_length <= self.length);
+        assert!(new_length <= self.length && start <= self.length - new_length);
         Tensor {
             data: self.data.clone(),
             shape: shape.clone(),
@@ -61,8 +61,6 @@ impl<T: Copy + Clone + Default> Tensor<T> {
             length: new_length,
         }
     }
-
-
 }
 
 // Some helper functions for testing and debugging


### PR DESCRIPTION
- `self.offset`应该不计入`self.length`？
- 传入`self_attention`的`q`的shape如在`forward`下的layer loop中不再reshape的话，应为(seq, n_kv_h * n_groups, dqkv)