### PR TITLE
Clarify the self-attention layer documentation & code template

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ residual = output + residual
 
 第二，我们需要将 (seq_len, dim) 和 (dim, total_seq_len) 的两个矩阵做矩阵乘才能得到我们想要的形状，而现在的QK都不满足这个条件；你有几种不同的选择处理这个情况，一是对矩阵进行reshape和转置（意味着拷贝），再用一个支持广播（因为你需要对“头”进行正确对应）的矩阵乘进行计算，二是将这些矩阵视为多个向量，并按照正确的对应关系手动进行索引和向量乘法，这里我推荐使用更容易理解的后一种方法。
 
-同样的，在对权重矩阵进行完softmax后和V进行矩阵乘时也会遇到这个情况。
+同样的，在对权重矩阵进行完masked_softmax后和V进行矩阵乘时也会遇到这个情况。
 
 对于每个头，完整的Self-Attention层的计算过程如下；
 
@@ -148,7 +148,7 @@ K = cat(K_cache, K)
 V = cat(V_cache, V)
 ### 以下是你需要实现的部分
 score = Q @ K.T / sqrt(dim)
-attn = softmax(score)
+attn = masked_softmax(score)
 attn_V = attn @ V
 out = attn_V @ O_weight.T
 residual = out + residual

--- a/src/model.rs
+++ b/src/model.rs
@@ -87,6 +87,7 @@ impl Llama<f32> {
             OP::matmul_transb(q, 0., &hidden_states, &self.params.wq[layer], 1.0);
             OP::matmul_transb(k, 0., &hidden_states, &self.params.wk[layer], 1.0);
             OP::matmul_transb(v, 0., &hidden_states, &self.params.wv[layer], 1.0);
+            let o_transposed = &self.params.wo[layer]; // (seq, n_q_h * dqkv)
             OP::rope(
                 q.reshape(&vec![seq_len, self.n_q_h, self.dqkv]),
                 past_seq_len,
@@ -147,6 +148,7 @@ fn self_attention(
     q: &Tensor<f32>,                 // (seq, n_kv_h * n_groups * dqkv)
     k: &Tensor<f32>,                 // (total_seq, n_kv_h * dqkv)
     v: &Tensor<f32>,                 // (total_seq, n_kv_h * dqkv)
+    o_transposed: &Tensor<f32>,      // (seq, n_groups * n_kv_h * dqkv)
     n_kv_h: usize,
     n_groups: usize,
     seq_len: usize,

--- a/src/model.rs
+++ b/src/model.rs
@@ -87,7 +87,7 @@ impl Llama<f32> {
             OP::matmul_transb(q, 0., &hidden_states, &self.params.wq[layer], 1.0);
             OP::matmul_transb(k, 0., &hidden_states, &self.params.wk[layer], 1.0);
             OP::matmul_transb(v, 0., &hidden_states, &self.params.wv[layer], 1.0);
-            let o_transposed = &self.params.wo[layer]; // (seq, n_q_h * dqkv)
+            let o_weight = &self.params.wo[layer]; // (seq, n_q_h * dqkv)
             OP::rope(
                 q.reshape(&vec![seq_len, self.n_q_h, self.dqkv]),
                 past_seq_len,
@@ -148,7 +148,7 @@ fn self_attention(
     q: &Tensor<f32>,                 // (seq, n_kv_h * n_groups * dqkv)
     k: &Tensor<f32>,                 // (total_seq, n_kv_h * dqkv)
     v: &Tensor<f32>,                 // (total_seq, n_kv_h * dqkv)
-    o_transposed: &Tensor<f32>,      // (seq, n_groups * n_kv_h * dqkv)
+    o_weight: &Tensor<f32>,          // (seq, n_groups * n_kv_h * dqkv)
     n_kv_h: usize,
     n_groups: usize,
     seq_len: usize,


### PR DESCRIPTION
1. Attention层对score归一化应该用的是masked_softmax而不是softmax
2. 添加了给self_attention 的输入O_weight矩阵